### PR TITLE
Enable mypy to discover types hints as per PEP-561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     url="https://github.com/h5kure/base_repr.git",
     packages=setuptools.find_packages(),
+    package_data={"*": ["py.typed"]},
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Add the `py.typed` marker file and `package_data` entry from PEP-561.

Tested with `python3 -m build` command.