### PR TITLE
py.typed is not installed correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     url="https://github.com/h5kure/base_repr.git",
     packages=setuptools.find_packages(),
-    package_data={"*": ["py.typed"]},
+    package_data={"": ["py.typed"]},
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
By using `*` to match all packages, `py.typed` file is not installed correctly and that breaks MYPY discovery.

Tested on PY 3.8/3.9 on Macos/Linux